### PR TITLE
Updating of VIPS Yaml to use EPPO codes representing multiple species…

### DIFF
--- a/VIPS.yaml
+++ b/VIPS.yaml
@@ -180,80 +180,80 @@ models:
   pests:
   - HYLERA # EPPO code for Cabbage Fly
   crops:
-  - 1BRSG # EPPO code for the Brassica Genus
-  - BRSBL # Brassica balearica
-  - BRSBA # Brassica barrelieri
-  - BRSBO # Brassica bourgeaui
-  - BRSCA # Brassica carinata
-  - BRSCR # Brassica cretica
-  - BRSEL # Brassica elongata
-  - BRSEI # Brassica elongata subsp. integrifolia
-  - BRSFR # Brassica fruticulosa
-  - BRSGR # Brassica gravinae
-  - BRSHI # Brassica hilarionis
-  - BRSIN # Brassica incana
-  - BRSIS # Brassica insularis
-  - BRSJU # Brassica juncea
-  - BRSJC # Brassica juncea var. crispifolia
-  - BRSJJ # Brassica juncea var. japonica
-  - BRSJN # Brassica juncea var. napiformis
-  - BRSJR # Brassica juncea var. rugosa
-  - BRSMK # Brassica macrocarpa
-  - BRSMO # Brassica montana
-  - BRSNN # Brassica napus
-  - BRSNA # Brassica napus subsp. rapifera
-  - BRSNP # Brassica napus var. pabularia
-  - BRSNR # Brassica narinosa
-  - BRSNI # Brassica nigra
-  - BRSOX # Brassica oleracea
-  - BRSOP # Brassica oleracea var. acephala subvar. planta
-  - BRSAG # Brassica oleracea var. alboglabra
-  - BRSOB # Brassica oleracea var. botrytis
-  - BRSOL # Brassica oleracea var. capitata
-  - BRSOH # Brassica oleracea var. capitata f. alba
-  - BRSON # Brassica oleracea var. capitata f. conica
-  - BRSOR # Brassica oleracea var. capitata f. rubra
-  - BRSOD # Brassica oleracea var. costata
-  - BRSOF # Brassica oleracea var. gemmifera
-  - BRSOG # Brassica oleracea var. gongylodes
-  - BRSOK # Brassica oleracea var. italica
-  - BRSOO # Brassica oleracea var. longata
-  - BRSOM # Brassica oleracea var. medullosa
-  - BRSOI # Brassica oleracea var. palmifolia
-  - BRSOQ # Brassica oleracea var. ramosa
-  - BRSOS # Brassica oleracea var. sabauda
-  - BRSOT # Brassica oleracea var. sabauda subvar. fimbriata
-  - BRSOC # Brassica oleracea var. sabellica
-  - BRSSG # Brassica oleracea var. sabellica x var. gemmifera
-  - BRSOA # Brassica oleracea var. viridis
-  - BRSXY # Brassica oxyrrhina
-  - BRSPE # Brassica perviridis
-  - BRSPR # Brassica procumbens
-  - BRSRR # Brassica rapa
-  - BRSCH # Brassica rapa subsp. chinensis
-  - BRSNO # Brassica rapa subsp. nipposinica
-  - BRSRO # Brassica rapa subsp. oleifera
-  - BRSCC # Brassica rapa subsp. oleifera x subsp. chinensis
-  - BRSPK # Brassica rapa subsp. pekinensis
-  - BRSRA # Brassica rapa subsp. sylvestris
-  - BRSCF # Brassica rapa var. chinoleifera
-  - BRSRD # Brassica rapa var. dichotoma
-  - BRSRE # Brassica rapa var. esculenta
-  - BRSRG # Brassica rapa var. glabra
-  - BRSRS # Brassica rapa var. sarson
-  - BRSRT # Brassica rapa var. toria
-  - BRSRP # Brassica rapa x Brassica rapa subsp. pekinensis
-  - BRSRQ # Brassica repanda
-  - BRSGA # Brassica repanda subsp. galissieri
-  - BRSSX # Brassica repanda subsp. saxatilis
-  - BRSRU # Brassica rupestris
-  - BRSRW # Brassica ruvo
-  - BRSSE # Brassica septiceps
-  - BRSSO # Brassica souliei
+  #- 1BRSG # EPPO code for the Brassica Genus
+  #- BRSBL # Brassica balearica
+  #- BRSBA # Brassica barrelieri
+  #- BRSBO # Brassica bourgeaui
+  #- BRSCA # Brassica carinata
+  #- BRSCR # Brassica cretica
+  #- BRSEL # Brassica elongata
+  #- BRSEI # Brassica elongata subsp. integrifolia
+  #- BRSFR # Brassica fruticulosa
+  #- BRSGR # Brassica gravinae
+  #- BRSHI # Brassica hilarionis
+  #- BRSIN # Brassica incana
+  #- BRSIS # Brassica insularis
+  #- BRSJU # Brassica juncea
+  #- BRSJC # Brassica juncea var. crispifolia
+  #- BRSJJ # Brassica juncea var. japonica
+  #- BRSJN # Brassica juncea var. napiformis
+  #- BRSJR # Brassica juncea var. rugosa
+  #- BRSMK # Brassica macrocarpa
+  #- BRSMO # Brassica montana
+  #- BRSNN # Brassica napus
+  #- BRSNA # Brassica napus subsp. rapifera
+  #- BRSNP # Brassica napus var. pabularia
+  #- BRSNR # Brassica narinosa
+  #- BRSNI # Brassica nigra
+  #- BRSOX # Brassica oleracea
+  #- BRSOP # Brassica oleracea var. acephala subvar. planta
+  #- BRSAG # Brassica oleracea var. alboglabra
+  #- BRSOB # Brassica oleracea var. botrytis
+  #- BRSOL # Brassica oleracea var. capitata
+  #- BRSOH # Brassica oleracea var. capitata f. alba
+  #- BRSON # Brassica oleracea var. capitata f. conica
+  #- BRSOR # Brassica oleracea var. capitata f. rubra
+  #- BRSOD # Brassica oleracea var. costata
+  #- BRSOF # Brassica oleracea var. gemmifera
+  #- BRSOG # Brassica oleracea var. gongylodes
+  #- BRSOK # Brassica oleracea var. italica
+  #- BRSOO # Brassica oleracea var. longata
+  #- BRSOM # Brassica oleracea var. medullosa
+  #- BRSOI # Brassica oleracea var. palmifolia
+  #- BRSOQ # Brassica oleracea var. ramosa
+  #- BRSOS # Brassica oleracea var. sabauda
+  #- BRSOT # Brassica oleracea var. sabauda subvar. fimbriata
+  #- BRSOC # Brassica oleracea var. sabellica
+  #- BRSSG # Brassica oleracea var. sabellica x var. gemmifera
+  #- BRSOA # Brassica oleracea var. viridis
+  #- BRSXY # Brassica oxyrrhina
+  #- BRSPE # Brassica perviridis
+  #- BRSPR # Brassica procumbens
+  #- BRSRR # Brassica rapa
+  #- BRSCH # Brassica rapa subsp. chinensis
+  #- BRSNO # Brassica rapa subsp. nipposinica
+  #- BRSRO # Brassica rapa subsp. oleifera
+  #- BRSCC # Brassica rapa subsp. oleifera x subsp. chinensis
+  #- BRSPK # Brassica rapa subsp. pekinensis
+  #- BRSRA # Brassica rapa subsp. sylvestris
+  #- BRSCF # Brassica rapa var. chinoleifera
+  #- BRSRD # Brassica rapa var. dichotoma
+  #- BRSRE # Brassica rapa var. esculenta
+  #- BRSRG # Brassica rapa var. glabra
+  #- BRSRS # Brassica rapa var. sarson
+  #- BRSRT # Brassica rapa var. toria
+  #- BRSRP # Brassica rapa x Brassica rapa subsp. pekinensis
+  #- BRSRQ # Brassica repanda
+  #- BRSGA # Brassica repanda subsp. galissieri
+  #- BRSSX # Brassica repanda subsp. saxatilis
+  #- BRSRU # Brassica rupestris
+  #- BRSRW # Brassica ruvo
+  #- BRSSE # Brassica septiceps
+  #- BRSSO # Brassica souliei
   - BRSSS # Brassica sp.
-  - BRSSQ # Brassica spinescens
-  - BRSTO # Brassica tournefortii
-  - BRSVI # Brassica villosa
+  #- BRSSQ # Brassica spinescens
+  #- BRSTO # Brassica tournefortii
+  #- BRSVI # Brassica villosa
   keywords: none
   type_of_decision: Short-term tactical
   type_of_output: Risk indication
@@ -422,80 +422,80 @@ models:
   pests:
   - BARABR # EPPO code for Cabbage Moth
   crops:
-  - 1BRSG # EPPO code for the Brassica Genus
-  - BRSBL # Brassica balearica
-  - BRSBA # Brassica barrelieri
-  - BRSBO # Brassica bourgeaui
-  - BRSCA # Brassica carinata
-  - BRSCR # Brassica cretica
-  - BRSEL # Brassica elongata
-  - BRSEI # Brassica elongata subsp. integrifolia
-  - BRSFR # Brassica fruticulosa
-  - BRSGR # Brassica gravinae
-  - BRSHI # Brassica hilarionis
-  - BRSIN # Brassica incana
-  - BRSIS # Brassica insularis
-  - BRSJU # Brassica juncea
-  - BRSJC # Brassica juncea var. crispifolia
-  - BRSJJ # Brassica juncea var. japonica
-  - BRSJN # Brassica juncea var. napiformis
-  - BRSJR # Brassica juncea var. rugosa
-  - BRSMK # Brassica macrocarpa
-  - BRSMO # Brassica montana
-  - BRSNN # Brassica napus
-  - BRSNA # Brassica napus subsp. rapifera
-  - BRSNP # Brassica napus var. pabularia
-  - BRSNR # Brassica narinosa
-  - BRSNI # Brassica nigra
-  - BRSOX # Brassica oleracea
-  - BRSOP # Brassica oleracea var. acephala subvar. planta
-  - BRSAG # Brassica oleracea var. alboglabra
-  - BRSOB # Brassica oleracea var. botrytis
-  - BRSOL # Brassica oleracea var. capitata
-  - BRSOH # Brassica oleracea var. capitata f. alba
-  - BRSON # Brassica oleracea var. capitata f. conica
-  - BRSOR # Brassica oleracea var. capitata f. rubra
-  - BRSOD # Brassica oleracea var. costata
-  - BRSOF # Brassica oleracea var. gemmifera
-  - BRSOG # Brassica oleracea var. gongylodes
-  - BRSOK # Brassica oleracea var. italica
-  - BRSOO # Brassica oleracea var. longata
-  - BRSOM # Brassica oleracea var. medullosa
-  - BRSOI # Brassica oleracea var. palmifolia
-  - BRSOQ # Brassica oleracea var. ramosa
-  - BRSOS # Brassica oleracea var. sabauda
-  - BRSOT # Brassica oleracea var. sabauda subvar. fimbriata
-  - BRSOC # Brassica oleracea var. sabellica
-  - BRSSG # Brassica oleracea var. sabellica x var. gemmifera
-  - BRSOA # Brassica oleracea var. viridis
-  - BRSXY # Brassica oxyrrhina
-  - BRSPE # Brassica perviridis
-  - BRSPR # Brassica procumbens
-  - BRSRR # Brassica rapa
-  - BRSCH # Brassica rapa subsp. chinensis
-  - BRSNO # Brassica rapa subsp. nipposinica
-  - BRSRO # Brassica rapa subsp. oleifera
-  - BRSCC # Brassica rapa subsp. oleifera x subsp. chinensis
-  - BRSPK # Brassica rapa subsp. pekinensis
-  - BRSRA # Brassica rapa subsp. sylvestris
-  - BRSCF # Brassica rapa var. chinoleifera
-  - BRSRD # Brassica rapa var. dichotoma
-  - BRSRE # Brassica rapa var. esculenta
-  - BRSRG # Brassica rapa var. glabra
-  - BRSRS # Brassica rapa var. sarson
-  - BRSRT # Brassica rapa var. toria
-  - BRSRP # Brassica rapa x Brassica rapa subsp. pekinensis
-  - BRSRQ # Brassica repanda
-  - BRSGA # Brassica repanda subsp. galissieri
-  - BRSSX # Brassica repanda subsp. saxatilis
-  - BRSRU # Brassica rupestris
-  - BRSRW # Brassica ruvo
-  - BRSSE # Brassica septiceps
-  - BRSSO # Brassica souliei
+  #- 1BRSG # EPPO code for the Brassica Genus
+  #- BRSBL # Brassica balearica
+  #- BRSBA # Brassica barrelieri
+  #- BRSBO # Brassica bourgeaui
+  #- BRSCA # Brassica carinata
+  #- BRSCR # Brassica cretica
+  #- BRSEL # Brassica elongata
+  #- BRSEI # Brassica elongata subsp. integrifolia
+  #- BRSFR # Brassica fruticulosa
+  #- BRSGR # Brassica gravinae
+  #- BRSHI # Brassica hilarionis
+  #- BRSIN # Brassica incana
+  #- BRSIS # Brassica insularis
+  #- BRSJU # Brassica juncea
+  #- BRSJC # Brassica juncea var. crispifolia
+  #- BRSJJ # Brassica juncea var. japonica
+  #- BRSJN # Brassica juncea var. napiformis
+  #- BRSJR # Brassica juncea var. rugosa
+  #- BRSMK # Brassica macrocarpa
+  #- BRSMO # Brassica montana
+  #- BRSNN # Brassica napus
+  #- BRSNA # Brassica napus subsp. rapifera
+  #- BRSNP # Brassica napus var. pabularia
+  #- BRSNR # Brassica narinosa
+  #- BRSNI # Brassica nigra
+  #- BRSOX # Brassica oleracea
+  #- BRSOP # Brassica oleracea var. acephala subvar. planta
+  #- BRSAG # Brassica oleracea var. alboglabra
+  #- BRSOB # Brassica oleracea var. botrytis
+  #- BRSOL # Brassica oleracea var. capitata
+  #- BRSOH # Brassica oleracea var. capitata f. alba
+  #- BRSON # Brassica oleracea var. capitata f. conica
+  #- BRSOR # Brassica oleracea var. capitata f. rubra
+  #- BRSOD # Brassica oleracea var. costata
+  #- BRSOF # Brassica oleracea var. gemmifera
+  #- BRSOG # Brassica oleracea var. gongylodes
+  #- BRSOK # Brassica oleracea var. italica
+  #- BRSOO # Brassica oleracea var. longata
+  #- BRSOM # Brassica oleracea var. medullosa
+  #- BRSOI # Brassica oleracea var. palmifolia
+  #- BRSOQ # Brassica oleracea var. ramosa
+  #- BRSOS # Brassica oleracea var. sabauda
+  #- BRSOT # Brassica oleracea var. sabauda subvar. fimbriata
+  #- BRSOC # Brassica oleracea var. sabellica
+  #- BRSSG # Brassica oleracea var. sabellica x var. gemmifera
+  #- BRSOA # Brassica oleracea var. viridis
+  #- BRSXY # Brassica oxyrrhina
+  #- BRSPE # Brassica perviridis
+  #- BRSPR # Brassica procumbens
+  #- BRSRR # Brassica rapa
+  #- BRSCH # Brassica rapa subsp. chinensis
+  #- BRSNO # Brassica rapa subsp. nipposinica
+  #- BRSRO # Brassica rapa subsp. oleifera
+  #- BRSCC # Brassica rapa subsp. oleifera x subsp. chinensis
+  #- BRSPK # Brassica rapa subsp. pekinensis
+  #- BRSRA # Brassica rapa subsp. sylvestris
+  #- BRSCF # Brassica rapa var. chinoleifera
+  #- BRSRD # Brassica rapa var. dichotoma
+  #- BRSRE # Brassica rapa var. esculenta
+  #- BRSRG # Brassica rapa var. glabra
+  #- BRSRS # Brassica rapa var. sarson
+  #- BRSRT # Brassica rapa var. toria
+  #- BRSRP # Brassica rapa x Brassica rapa subsp. pekinensis
+  #- BRSRQ # Brassica repanda
+  #- BRSGA # Brassica repanda subsp. galissieri
+  #- BRSSX # Brassica repanda subsp. saxatilis
+  #- BRSRU # Brassica rupestris
+  #- BRSRW # Brassica ruvo
+  #- BRSSE # Brassica septiceps
+  #- BRSSO # Brassica souliei
   - BRSSS # Brassica sp.
-  - BRSSQ # Brassica spinescens
-  - BRSTO # Brassica tournefortii
-  - BRSVI # Brassica villosa
+  #- BRSSQ # Brassica spinescens
+  #- BRSTO # Brassica tournefortii
+  #- BRSVI # Brassica villosa
   keywords: none
   type_of_decision: Short-term tactical
   type_of_output: Risk indication
@@ -1571,11 +1571,12 @@ models:
   pests:
   - BREMLA # EPPO code for Downy mildew of lettuce
   crops:
-  - LACSA # Lactuca sativa
-  - LACSC # Lactuca sativa var. capitata
-  - LACSP # Lactuca sativa var. crispa
-  - LACSO # Lactuca sativa var. longifolia
-  - LACSE # Lactuca serriola
+  #- LACSA # Lactuca sativa
+  #- LACSC # Lactuca sativa var. capitata
+  #- LACSP # Lactuca sativa var. crispa
+  #- LACSO # Lactuca sativa var. longifolia
+  #- LACSE # Lactuca serriola
+  - LACSS # Lactuca spp - Lettuce species
   keywords: none
   type_of_decision: Short-term tactical
   type_of_output: Risk indication


### PR DESCRIPTION
Where the DSS does not differentiate between individual species, it is better, where possible to use an EPPO code that represents a genera. 
This is particularly important for brassicas, where there is a very large number of species grown and the EPPO code conversion will produce a large number ofduplicate entries that the UI or backend has to filter to make unique.

I felt that as there was an EPPO code to represent the brassica genus (BRSSS) that this should be used instead as it simplifies display to the user, removing the need for the user to select from a large number of potential crops.

I have also done the same for the Bremia lactuca model as the DSS does not distinguish between different lettuce species or varieties, replacing these with LACSS.

The aim with the EPPO codes should be to use the minimum number possible to represent the species/varieties that the model can cover.